### PR TITLE
Allow passing a proc to calculate components

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ end
 
 ### ```components```
 
-Type: `[components_x, components_y]`
+Type: `[components_x, components_y]` or a `Proc`
 Default: `[4, 3]`
 
 ```ruby
@@ -52,6 +52,12 @@ plugin :blurhash, components: [2, 2]
 ```
 
 This allows you to customize the number of components on each axis for the Blurhash algorithm. The visual result will look like a grid of `X * Y` blurred colors.
+
+You can also pass a proc which receive the width and height and calculate the components on-the-fly:
+
+```ruby
+plugin :blurhash, components: ->(width, height) { [width / 600, height / 600] }
+```
 
 ### `resize_to`
 

--- a/lib/shrine/plugins/blurhash.rb
+++ b/lib/shrine/plugins/blurhash.rb
@@ -46,8 +46,8 @@ class Shrine
           blurhash = instrument_blurhash(io) do
             pixels = extractor.call(*args)
 
-            components = opts[:blurhash][:components]
-            ::Blurhash.encode(pixels[:width], pixels[:height], pixels[:pixels], x_comp: components[0], y_comp: components[1])
+            x_comp, y_comp = components_for(pixels[:width], pixels[:height])
+            ::Blurhash.encode(pixels[:width], pixels[:height], pixels[:pixels], x_comp: x_comp, y_comp: y_comp)
           end
 
           io.rewind
@@ -72,6 +72,13 @@ class Shrine
         end
 
         private
+
+        def components_for(width, height)
+          if opts[:blurhash][:components].respond_to?(:call)
+            opts[:blurhash][:components].call(width, height)
+          else opts[:blurhash][:components]
+          end
+        end
 
         # Sends a `blurhash.shrine` event for instrumentation plugin.
         def instrument_blurhash(io, &block)

--- a/test/blurhash_test.rb
+++ b/test/blurhash_test.rb
@@ -31,6 +31,11 @@ describe Shrine::Plugins::Blurhash do
     assert_equal "AEHLk~jbpyoK", @shrine.compute_blurhash(image)
   end
 
+  it "allows passing a proc to calculate components" do
+    @shrine.plugin :blurhash, components: ->(_w, _h) { [2, 2] }
+    assert_equal "AEHLk~jbpyoK", @shrine.compute_blurhash(image)
+  end
+
   it "allows to customize resize dimensions" do
     @shrine.plugin :blurhash, resize_to: 200
     assert_equal "LLHV6naf2xk9lAoKaeR*%fkBMxn*", @shrine.compute_blurhash(image)


### PR DESCRIPTION
# What
Allows setting a proc or lambda to calculate components based on width and height of the resized image!

# Why

The blurhash docs suggest the following regarding choosing the component numbers:

> ## [How do I pick the number of X and Y components?](https://github.com/woltapp/blurhash#how-do-i-pick-the-number-of-x-and-y-components)
>
> It depends a bit on taste. The more components you pick, the more information is retained in the placeholder, but the longer the BlurHash string will be. Also, it doesn't always look good with too many components. We usually go with 4 by 3, which seems to strike a nice balance.
>
> However, **you should adjust the number of components depending on the aspect ratio of your images**. For instance, very wide images should have more X components and fewer Y components.

I've experimented with a number of different options for calculating component numbers based on aspect ratio, but it really does depend on taste so I figured setting a proc was a good option to allow customization!

That said, this is the one I'm using:

```ruby
ratio = width.to_f / height
# Achieves the following
# - "component area" <= 15
# - maintains aspect ratio
# - clamps in the 2..5 range where it looks nicest
# Possible outputs are [2, 5], [3, 5], [3, 4], [3, 3], [4, 3], [5, 3], [5, 2]
x_comp = Math.sqrt(15.to_f / ratio).floor.clamp(2, 5)
y_comp = (x_comp * ratio).floor.clamp(2, 5)
[x_comp, y_comp]
```