### PR TITLE
Remove alpha channel from transparent images

### DIFF
--- a/lib/shrine/plugins/blurhash.rb
+++ b/lib/shrine/plugins/blurhash.rb
@@ -130,6 +130,7 @@ class Shrine
             Shrine.with_file(io) do |file|
               image = Vips::Image.new_from_file(file.path, access: :sequential)
               image = image.resize(resize_to.fdiv(image.width), vscale: resize_to.fdiv(image.height)) if resize_to
+              image = image.flatten if image.has_alpha?
 
               {
                 width: image.width,


### PR DESCRIPTION
This PR removes the alpha channel from transparent images. Transparency is not supported by blurhash, see https://github.com/woltapp/blurhash/issues/100.

The pixels array should have chunks of 3 bytes per pixel, but images which have an alpha channel (e.g. png files) have 4 bytes per pixel. This is also verified in https://github.com/Gargron/blurhash/commit/3d8a39c9edd4817dbabf58e80a38cc4c19c80f54 since version 0.1.8 which was released last week.

## fixes

This PR fixes #12.

## possible improvements

The `flatten` method used here takes an optional argument `background:`. Adding this and making it configurable for users of this plugin would allow configuring a different background color than the default (white).

## alternatives

Users of this plugin might alternatively consider migrating to [thumbhash](https://github.com/evanw/thumbhash) if real transparency is needed.
